### PR TITLE
Fix bad initarg name

### DIFF
--- a/damn-fast-priority-queue/src.lisp
+++ b/damn-fast-priority-queue/src.lisp
@@ -253,5 +253,5 @@
   ((%queue :reader queue-size-limit-reached-queue :initarg :queue)
    (%object :reader queue-size-limit-reached-object :initarg :element))
   (:default-initargs :queue (a:required-argument :queue)
-                     :object (a:required-argument :object))
+                     :element (a:required-argument :element))
   (:report report-queue-size-limit-reached))

--- a/damn-fast-stable-priority-queue/src.lisp
+++ b/damn-fast-stable-priority-queue/src.lisp
@@ -307,5 +307,5 @@
   ((%queue :reader queue-size-limit-reached-queue :initarg :queue)
    (%object :reader queue-size-limit-reached-object :initarg :element))
   (:default-initargs :queue (a:required-argument :queue)
-                     :object (a:required-argument :object))
+                     :element (a:required-argument :element))
   (:report report-queue-size-limit-reached))


### PR DESCRIPTION
Under ECL and CLASP, the wrong name leads to a condition being raised inside the creation of a `queue-size-limit-reached` condition.